### PR TITLE
Ignore vim swapfiles by default

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -6,3 +6,5 @@
 Icon?
 Thumbs.db
 ehthumbs.db
+*.swp
+*.swo


### PR DESCRIPTION
These files are created by vim while editing and removed when a file is closed. They're generally ignored globally by vim users.
