### PR TITLE
Includes git-promp.sh in the bash completion like homebrew does

### DIFF
--- a/files/brews/git.rb
+++ b/files/brews/git.rb
@@ -68,6 +68,7 @@ class Git < Formula
 
     # install the completion script first because it is inside 'contrib'
     (prefix+'etc/bash_completion.d').install 'contrib/completion/git-completion.bash'
+    (prefix+'etc/bash_completion.d').install 'contrib/completion/git-prompt.sh'
     (share+'git-core').install 'contrib'
 
     # We could build the manpages ourselves, but the build process depends


### PR DESCRIPTION
See https://github.com/mxcl/homebrew/pull/14312

You'll want to tag after this and then update boxen to refect the new version (I suggest 1.0.1)
