### PR TITLE
Add support to initially clone a repo from git

### DIFF
--- a/manifests/clone.pp
+++ b/manifests/clone.pp
@@ -1,0 +1,49 @@
+# Clones a specific git repository
+#
+# Usage:
+#    git::clone{"https://github.com/my/repo":
+#       path   => "/path/to/where/clone/goes",
+#       target => "name_to_clone_into"
+#
+# Note:
+#   You SHOULD use HTTPS as the transport for your git repos. If you choose not
+#   to, be sure to specificy a target value or your repo will be cloned into an
+#   odd location
+
+define git::clone(
+  $path,
+  $target = ''
+){
+  require boxen::config
+
+  $repo_name = $name ? {
+    /^https.*\.git$/ => regsubst($name, '^https:.*/([^/]+)\.git$', '\1'),
+    /^https.*[^\/]$/ => regsubst($name, '^https:.*/([^/]+)$', '\1'),
+    /\.git$/         => regsubst($name, '.*/([^/]+)\.git$', '\1'),
+    default          => fail("Unable to parse out repo name: ${name}")
+  }
+
+  $clone_tgt = $target ? {
+    ''      => "${path}/${repo_name}",
+    default => "${path}/${target}"
+  }
+  if !defined(File[$path]){
+    file{$path:
+      ensure => directory,
+      owner  => $::luser,
+      mode   => '0700'
+    }
+  }
+
+  exec{"git clone ${name}":
+    cwd       => $path,
+    path      => "${boxen::config::homebrewdir}/bin",
+    user      => $::luser,
+    logoutput => true,
+    command   => "hub clone ${name} ${clone_tgt}",
+    creates   => $clone_tgt,
+    require   => [Class['git'], File[$path]],
+    timeout   => 0
+  }
+}
+

--- a/spec/defines/git__clone_spec.rb
+++ b/spec/defines/git__clone_spec.rb
@@ -1,0 +1,57 @@
+
+require 'spec_helper'
+
+describe 'git::clone' do
+  let(:boxenhome) { '/opt/boxen' }
+  let(:params){ {:path => '/Users/user/my_space' } }
+  let(:facts) do
+    {
+      :boxen_home => boxenhome,
+      :boxen_user => 'pcollins',
+      :luser      => 'paulcollins',
+    }
+  end
+
+  describe "with invalid name" do
+    let(:title){ 'https://test.com/user/repo_name/' }
+    it{ expect { should contain_exec("git clone #{title}") }.to raise_error(Puppet::Error)}
+  end
+
+  describe "with valid name" do
+    let(:title){ 'https://test.com/user/repo_name' }
+    it do
+      should contain_exec("git clone #{title}").with({
+        :command => "hub clone #{title} #{params[:path]}/repo_name",
+        :creates => "#{params[:path]}/repo_name",
+        :cwd     => "#{params[:path]}",
+        :path    => "#{boxenhome}/homebrew/bin",
+        :user    => "#{facts[:luser]}",
+
+      })
+    end
+  end
+
+  describe "with valid name ending in .git" do
+    let(:title){ 'https://test.com/user/repo_name.git' }
+    it do
+      should contain_exec("git clone #{title}").with({
+        :command => "hub clone #{title} #{params[:path]}/repo_name",
+        :creates => "#{params[:path]}/repo_name",
+        :cwd     => "#{params[:path]}",
+        :path    => "#{boxenhome}/homebrew/bin",
+        :user    => "#{facts[:luser]}",
+
+      })
+    end
+  end
+
+  describe "with non-https style repo" do
+    let(:title){ 'git@github.com:user/repo_name.git' }
+    it do
+      should contain_exec("git clone #{title}").with({
+        :command => "hub clone #{title} #{params[:path]}/repo_name",
+      })
+    end
+  end
+
+end


### PR DESCRIPTION
Useful for having boxen initially populate a development envrionment
with all the repos a person needs. 

This is a bit limited since I'm parsing out the name of the repo is a slightly janky way. If there's a better way to get the git repo name please let me know so I can update this.
