### PR TITLE
Fix completions option handling

### DIFF
--- a/files/brews/git.rb
+++ b/files/brews/git.rb
@@ -21,6 +21,8 @@ class Git < Formula
   depends_on 'gettext' => :optional
 
   option 'with-blk-sha1', 'Compile with the block-optimized SHA1 implementation'
+  option 'without-completions', 'Disable bash/zsh completions from "contrib" directory'
+
 
   def install
     # If these things are installed, tell Git build system to not use them


### PR DESCRIPTION
The completion script was not working because the `without-completions` option doesn't exist, so the block inside [this conditional will not run](https://github.com/boxen/puppet-git/blob/master/files/brews/git.rb#L69)

https://github.com/boxen/puppet-git/commit/6d1722c25da2252cf414c44d84ee180f7889d4d0 was pushed in 1.2.1 and 1.2.2 but since it is not on master branch the 1.2.3 tag doesn't include this commit.

This is a cherry pick of the above commit to fix the issues with the complations scripts.
