### PR TITLE
Use literal ^M control characters in gitignore

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -3,7 +3,7 @@
 .Spotlight-V100
 .Trashes
 ._*
-Icon?
+Icon
 Thumbs.db
 ehthumbs.db
 *.swp


### PR DESCRIPTION
@wfarr Would like your eyes on this as it's a modification to the GitHub default gitignore file. The diff doesn't show the control characters but https://github.com/fromonesrc/puppet-git/compare#L0L6 is really `Icon^M^M`

Fixes #16

http://blog.bitfluent.com/post/173740409/ignoring-icon-in-gitignore
