### PR TITLE
Upgrade to Git 1.8.4.2 to default version.

### DIFF
--- a/files/brews/git.rb
+++ b/files/brews/git.rb
@@ -12,8 +12,8 @@ end
 
 class Git < Formula
   homepage 'http://git-scm.com'
-  url 'http://git-core.googlecode.com/files/git-1.8.4.tar.gz'
-  sha1 '2a361a2d185b8bc604f7f2ce2f502d0dea9d3279'
+  url 'http://git-core.googlecode.com/files/git-1.8.4.2.tar.gz'
+  sha1 'f2e9317703553b4215700605c15d0f3a30623a9d'
 
   version '1.8.4-boxen1'
 


### PR DESCRIPTION
This is the latest stable version of Git that is available from the formula in Homebrew. I'm not sure what the regular process is for upgrading this. 
