### PR TITLE
WIP: HEAD to the Git Homebrew formula

### DIFF
--- a/files/brews/git.rb
+++ b/files/brews/git.rb
@@ -14,6 +14,7 @@ class Git < Formula
   homepage 'http://git-scm.com'
   url 'http://git-core.googlecode.com/files/git-1.8.4.tar.gz'
   sha1 '2a361a2d185b8bc604f7f2ce2f502d0dea9d3279'
+  head 'https://github.com/git/git.git'
 
   version '1.8.4-boxen1'
 


### PR DESCRIPTION
This option matches the [default Homebrew formula](https://github.com/mxcl/homebrew/blob/master/Library/Formula/git.rb) which allows for installation using the --HEAD flag passed to Homebrew. Our main need for this is to support multiple corporate proxies in a single git configuration. The next version of Git will support that.
