### PR TITLE
Update Travis configuration to build 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:
   - "1.8.7"
+  - "2.0.0"
+matrix:
+  allow_failures:
+    - rvm: "2.0.0"


### PR DESCRIPTION
The latest version of OS X ships with 2.0.0 Ruby. We should at least
build against it but allow for failures.
