### PR TITLE
Fix SHA from my Emacs pinky.

### DIFF
--- a/files/brews/git.rb
+++ b/files/brews/git.rb
@@ -7,7 +7,7 @@ end
 
 class GitHtmldocs < Formula
   url 'http://git-core.googlecode.com/files/git-htmldocs-1.8.4.2.tar.gz'
-  sha1 'b0d5e7e24aba1af4a8e1a4fa9c894c3a673bf5d8g'
+  sha1 'b0d5e7e24aba1af4a8e1a4fa9c894c3a673bf5d8'
 end
 
 class Git < Formula


### PR DESCRIPTION
The SHA are located:
https://code.google.com/p/git-core/downloads/detail?name=git-htmldocs-1.8.4.2.tar.gz&can=2&q=
