### PR TITLE
Multiple properties per local repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Install [Git](http://git-scm.com), a stupid content tracker.
 ```puppet
 include git
 
-git::config::local { '/path/to/my/repo':
+git::config::local { 'repo_specific_email':
   ensure => present,
+  repo   => '/path/to/my/repo',
   key    => 'user.email',
   value  => 'turnt@example.com'
 }

--- a/manifests/config/local.pp
+++ b/manifests/config/local.pp
@@ -1,9 +1,9 @@
 # Public: Set a git configuration option for a specific repository.
 #
-# namevar - The String path to the git repository (if repo is not defined).
-# repo    - The String path to the git repository.
+# namevar - Will be used as the String path to the git repository if repo is not defined.
 # key     - The String name of the configuration option.
 # value   - The String value of the configuration option.
+# repo    - The String path to the git repository.
 # ensure  - The desired state of the resource as a String.  Valid values are
 #           'present' and 'absent' (default: 'present').
 #


### PR DESCRIPTION
This change decouples the definition of the repository to configure from the name variable. Thus allowing multiple configuration properties to be defined for a single local repository.
