### PR TITLE
Don't always ignore "tags" files/dirs

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -11,4 +11,4 @@ ehthumbs.db
 *.orig
 *~
 \#*\#
-tags
+/tags


### PR DESCRIPTION
Right now the default .gitignore ignores all "tags" files and directories.  This causes issues when you have files like `app/views/tags`

It appears the old method was added to due "ctags" which is an code indexing tool.  It appears to put its data in a "tags" file in the root of the project by default.

This PR instead only ignores files named "tags" in the root project dir.
