### PR TITLE
Method dev_tools_prefix no longs exists in Homebrew.

### DIFF
--- a/files/brews/git.rb
+++ b/files/brews/git.rb
@@ -45,8 +45,8 @@ class Git < Formula
     ENV['PYTHON_PATH'] = which 'python'
     ENV['PERL_PATH'] = which 'perl'
 
-    if MacOS.version >= :mavericks and MacOS.dev_tools_prefix
-      ENV['PERLLIB_EXTRA'] = "#{MacOS.dev_tools_prefix}/Library/Perl/5.16/darwin-thread-multi-2level"
+    if MacOS.version >= :mavericks 
+      ENV['PERLLIB_EXTRA'] = "#{MacOS.active_developer_dir}/Library/Perl/5.16/darwin-thread-multi-2level"
     end
 
     unless quiet_system ENV['PERL_PATH'], '-e', 'use ExtUtils::MakeMaker'


### PR DESCRIPTION
Method dev_tools_prefix has been removed from Homebrew.
