### PR TITLE
Add missing package provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,10 +18,15 @@ class git (
     homebrew::formula { 'git':
       before => Package[$package]
     }
-  }
 
-  package { $package:
-    ensure => $version,
+    package { $package:
+      ensure   => $version,
+      provider => homebrew
+    }
+  } else {
+    package { $package:
+      ensure => $version
+    }
   }
 
   file { $configdir:

--- a/spec/classes/git_spec.rb
+++ b/spec/classes/git_spec.rb
@@ -29,7 +29,10 @@ describe 'git' do
 
     should contain_homebrew__formula('git')
 
-    should contain_package('boxen/brews/git').with_ensure('2.3.0')
+    should contain_package('boxen/brews/git').with({
+      :ensure => '2.3.0',
+      :provider => 'homebrew',
+    })
 
     should contain_file(configdir).with_ensure('directory')
 
@@ -55,6 +58,17 @@ describe 'git' do
 
     should_not contain_git__config__global('user.name')
     should_not contain_git__config__global('user.email')
+  end
+
+  context "Linux" do
+    let(:facts) { default_test_facts.merge(:osfamily => 'Linux') }
+
+    it do
+      should contain_package('boxen/brews/git').with({
+        :ensure => '2.3.0',
+        :provider => nil,
+      })
+    end
   end
 
   context 'when the global_excludesfile parameter is set' do


### PR DESCRIPTION
Resubmitting #50 as I opened the PR from `master` on my fork (really donno why did I have such a bad idea).

The current version of this module expects, that user has set `homebrew` as a default package provider elsewhere (e.g. in `site.pp`) while it may not be necessarily true.

If `homebrew` is not set as default `provider`, then the git package installation ends up in following error:

```
Error: Parameter ensure failed on Package[boxen/brews/git]: Provider must have features 'versionable' to set 'ensure' to '2.1.2-boxen1' at /opt/boxen/repo/shared/git/manifests/init.pp:25
Wrapped exception:
Provider must have features 'versionable' to set 'ensure' to '2.1.2-boxen1'
Wrapped exception:
Provider must have features 'versionable' to set 'ensure' to '2.1.2-boxen1'
```