### PR TITLE
[Fixes #67] Upgrade `data/Darwin.yaml` for 2.4.3

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -2,7 +2,7 @@
 git::configdir: "%{::boxen::config::configdir}/git"
 
 git::package: 'boxen/brews/git'
-git::version: '2.4.0'
+git::version: '2.4.3'
 
 git::credentialhelper: "%{::boxen::config::repodir}/script/boxen-git-credential"
 git::global_credentialhelper: "%{boxen::config::home}/bin/boxen-git-credential"


### PR DESCRIPTION
https://github.com/boxen/puppet-git/pull/66 upgraded the Git version to 2.4.3
but it didn't also upgrade the version in `data/Darwin.yaml`.

This works fine when using boxen to upgrade but when using boxen on a fresh
install it fails as it initially tries to downgrade Git to 2.4.0.