### PR TITLE
Make it possible to skip setting core.excludesfile git setting 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,9 +57,11 @@ class git (
     require => File[$configdir]
   }
 
-  git::config::global{ 'core.excludesfile':
-    value   => $global_excludesfile,
-    require => File["${configdir}/gitignore"]
+  if $global_excludesfile {
+    git::config::global{ 'core.excludesfile':
+      value   => $global_excludesfile,
+      require => File["${configdir}/gitignore"]
+    }
   }
 
   if $::gname {

--- a/spec/classes/git_spec.rb
+++ b/spec/classes/git_spec.rb
@@ -81,6 +81,14 @@ describe 'git' do
     end
   end
 
+  context 'when the global_excludesfile parameter is set to false' do
+    let(:params) { default_params.merge({ :global_excludesfile => false }) }
+
+    it do
+      should_not contain_git__config__global('core.excludesfile')
+    end
+  end
+
   context 'when gname fact is set' do
     let(:facts) do
       default_test_facts.merge({


### PR DESCRIPTION
Setting `git::excludesfile` to false causes the class to skip setting the "core.excludesfile" git config setting in the user's gitconfig file. This is consistent with how the `git::credentialhelper` param works.