### PR TITLE
Manage permissions on `.gitconfig`

### DIFF
--- a/manifests/config/global.pp
+++ b/manifests/config/global.pp
@@ -17,7 +17,8 @@ define git::config::global($value) {
   $path = "/Users/${::boxen_user}/.gitconfig"
 
   file { $path:
-    owner => $::boxen_user
+    owner => $::boxen_user,
+    mode  => '0644'
   }
 
   ini_setting { "set ${name} to ${value} in ${path}":

--- a/manifests/config/global.pp
+++ b/manifests/config/global.pp
@@ -16,6 +16,10 @@ define git::config::global($value) {
   $split_key = split($name, '\.')
   $path = "/Users/${::boxen_user}/.gitconfig"
 
+  file { $path:
+    owner => $::boxen_user
+  }
+
   ini_setting { "set ${name} to ${value} in ${path}":
     ensure  => present,
     path    => $path,


### PR DESCRIPTION
During a recent boxenating, this file was discovered to be owned by root
instead of the usual boxen user. To rememdy this, we explicitly set this
file's ownership.
