### PR TITLE
Bump git to 2.9.0

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -2,7 +2,7 @@
 git::configdir: "%{::boxen::config::configdir}/git"
 
 git::package: 'boxen/brews/git'
-git::version: '2.8.1'
+git::version: '2.9.0'
 
 git::credentialhelper: "%{::boxen::config::repodir}/script/boxen-git-credential"
 git::global_credentialhelper: "%{boxen::config::home}/bin/boxen-git-credential"


### PR DESCRIPTION
This updates the default version of git to be 2.9.0. Full changelog can
be seen at https://github.com/git/git/blob/v2.9.0/Documentation/RelNotes/2.9.0.txt