### PR TITLE
Bump git to `2.12.2`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
+sudo: false
 script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:
-  - "1.8.7"
   - "2.0.0"

--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -2,7 +2,7 @@
 git::configdir: "%{::boxen::config::configdir}/git"
 
 git::package: 'boxen/brews/git'
-git::version: '2.11.0'
+git::version: '2.12.2'
 
 git::credentialhelper: "%{::boxen::config::repodir}/script/boxen-git-credential"
 git::global_credentialhelper: "%{boxen::config::home}/bin/boxen-git-credential"


### PR DESCRIPTION
Updates the vendored version of the formulae to use git 2.12.2

Changelog: https://github.com/git/git/blob/master/Documentation/RelNotes/2.12.2.txt