### PR TITLE
Fix `depends_on` deprecation

### DIFF
--- a/files/brews/git.rb
+++ b/files/brews/git.rb
@@ -32,10 +32,10 @@ class Git < Formula
 
   if build.with? "subversion"
     depends_on "subversion"
-    depends_on :perl => ["5.6", :recommended]
+    depends_on "perl" => ["5.6", :recommended]
   else
     option "with-perl", "Build against a custom Perl rather than system default"
-    depends_on :perl => ["5.6", :optional]
+    depends_on "perl" => ["5.6", :optional]
   end
 
   resource "html" do


### PR DESCRIPTION
Updates git Homebrew formula to use a string for the perl `depends_on`
and resolves the following error message during runs.

```
Warning: Calling 'depends_on :perl' is deprecated!
Use 'depends_on "perl"' instead.
/usr/local/Library/Taps/boxen/homebrew-brews/git.rb:38:in `<class:Git>'
Please report this to the boxen/brews tap!
```